### PR TITLE
Use Python 2.7 to test on Jenkins: `zc.buildout` 2.9.2 isn't compatible with Python 2.6

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -4,5 +4,5 @@ extends =
     versions.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-versions.cfg
 
-jenkins_python = $PYTHON26
+jenkins_python = $PYTHON27
 package-name = ftw.bridge.proxy


### PR DESCRIPTION
Use Python 2.7 to test on Jenkins: `zc.buildout` 2.9.2 isn't compatible with Python 2.6 any more because of [this dict comprehension](https://github.com/buildout/buildout/commit/fbb8c37b9cd2e303c37528b4f3e488bceff47f1b#diff-784f9bb654bbcee96dcbc547bbddd493R212).
